### PR TITLE
Add generic regridding function to XESMF.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "XESMF"
 uuid = "2e0b0046-e7a1-486f-88de-807ee8ffabe5"
 authors = ["NumericalEarth and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.3"
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 

--- a/src/XESMF.jl
+++ b/src/XESMF.jl
@@ -3,6 +3,7 @@ module XESMF
 using CondaPkg
 using PythonCall
 using SparseArrays
+using LinearAlgebra
 
 struct Regridder{S, M, V1, V2}
     method :: M
@@ -38,6 +39,16 @@ function sparse_regridder_weights(FT, regridder)
     weights = sparse(rows, cols, vals, shape[1], shape[2])
 
     return weights
+end
+
+# Generic regridding function that does not check the dimensions of the `src` and
+# `dst` arrays
+function regrid!(dst::AbstractVector, regridder::Regridder, src::AbstractVector)
+    regridder.src_temp .= src
+    LinearAlgebra.mul!(regridder.dst_temp, regridder.weights, regridder.src_temp)
+    dst .= regridder.dst_temp
+
+    return dst
 end
 
 sparse_regridder_weights(regridder) = sparse_regridder_weights(Float64, regridder)


### PR DESCRIPTION
I was thinking we could also add a generic regridding function to this package, since we have already `src_temp` and `dst_temp`. 

In this way, we can avoid the dependency on `LinearAlgebra` in our extensions