### PR TITLE
Bump version from 0.1.5 to 0.1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "XESMF"
 uuid = "2e0b0046-e7a1-486f-88de-807ee8ffabe5"
 authors = ["NumericalEarth and contributors"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"


### PR DESCRIPTION
version 1.5 does not have the function `xesmf_coordinates` exported.
This bump captures the commit that does the renaming https://github.com/NumericalEarth/XESMF.jl/commit/c6bfc93ad3651fa4532a49d452c52eac88e8b5f5