### PR TITLE
Update Oceananigans compat to include 0.109

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "XESMF"
 uuid = "2e0b0046-e7a1-486f-88de-807ee8ffabe5"
 authors = ["NumericalEarth and contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
@@ -17,7 +17,7 @@ XESMFOceananigansExt = "Oceananigans"
 
 [compat]
 CondaPkg = "0.2.31"
-Oceananigans = "0.107, 0.108"
+Oceananigans = "0.107, 0.108, 0.109"
 PythonCall = "0.9.27"
 SparseArrays = "1"
 Test = "1"


### PR DESCRIPTION
## Summary

- Adds Oceananigans 0.109 to the compat range for `XESMFOceananigansExt`
- Bumps version to 0.2.1

Oceananigans 0.109's only breaking change is the `time_discretization` syntax, which is not used by the extension, so the existing extension code works against 0.109 unchanged.

Motivation: [JuliaGeo/ConservativeRegridding.jl#104](https://github.com/JuliaGeo/ConservativeRegridding.jl/pull/104) wants to add Oceananigans 0.109 support but is blocked because Pkg downgrades XESMF to v0.1.6 (no Oceananigans extension) when 0.109 is allowed.

Supersedes #22 (now from the upstream branch so CI can run automatically).

## Test plan

- [ ] CI passes on this PR
- [ ] Verified via [JuliaGeo/ConservativeRegridding.jl#104](https://github.com/JuliaGeo/ConservativeRegridding.jl/pull/104) pointing test/Project.toml [sources] at this branch